### PR TITLE
Some cleanup, dependency updates

### DIFF
--- a/Scrobbler/Core/LastFmService.cs
+++ b/Scrobbler/Core/LastFmService.cs
@@ -19,14 +19,14 @@ public class LastFmService
         _appSettings = appSettings;
         _logger = logger;
     }
-    
+
     private const string BaseUrl = "https://ws.audioscrobbler.com/2.0/";
     private const string RegistryKeyPath = @"Software\Yoeksa\Scrobbler";
     private const string RegistrySessionKeyValueName = "session_key";
-    
+
     private AuthenticationToken? _token;
     private SessionDc? _session;
-    
+
     public async Task<bool> ScrobbleTracksAsync(List<TrackMetadata> tracks)
     {
         await EnsureAuthenticatedAsync();
@@ -41,12 +41,12 @@ public class LastFmService
         for (var i = 0; i < tracks.Count; i++)
         {
             var track = tracks[i];
-            
+
             formData.Add($"artist[{i}]", track.ArtistName);
             formData.Add($"track[{i}]", track.TrackName);
             formData.Add($"timestamp[{i}]", track.PlayingSince.ToUnixTimestamp().ToString());
             formData.Add($"duration[{i}]", ((int)track.TrackDuration.TotalSeconds).ToString());
-            
+
             if (track.AlbumName.IsNonEmpty()) formData.Add($"album[{i}]", track.AlbumName!);
             if (track.TrackNumber.HasValue) formData.Add($"trackNumber[{i}]", track.TrackNumber.Value.ToString());
             if (track.AlbumArtistName.IsNonEmpty()) formData.Add($"albumArtist[{i}]", track.AlbumArtistName!);
@@ -58,14 +58,15 @@ public class LastFmService
         }
         catch (LastFmErrorException e)
         {
+            _logger.LogDebug("LastFM Exception {Code}: {Err}", e.Code, e.Message);
             return false;
         }
-        
+
         if (_logger.IsEnabled(LogLevel.Debug))
             _logger.LogDebug($"Scrobbled {tracks.Count} tracks");
         return true;
     }
-    
+
     public async Task<LastFmTrackDc?> GetTrackAsync(string track, string artist)
     {
         var queryVals = new Dictionary<string, string>()
@@ -104,13 +105,13 @@ public class LastFmService
             Album = track.AlbumName,
             AlbumArtist = track.AlbumArtistName,
             TrackNumber = track.TrackNumber,
-            Duration = (int) track.TrackDuration.TotalSeconds
+            Duration = (int)track.TrackDuration.TotalSeconds
         });
-        
+
         if (_logger.IsEnabled(LogLevel.Debug))
             _logger.LogDebug("Updated Playing Now in LastFM");
     }
-    
+
     public async Task EnsureAuthenticatedAsync()
     {
         await EnsureHasTokenAsync();
@@ -141,11 +142,11 @@ public class LastFmService
             _session = new SessionDc(regSessionKey);
             return true;
         }
-        
+
         var queryVals = new Dictionary<string, string>
         {
             {"method", "auth.getSession"},
-            
+
             {"api_key", _appSettings.ApiKey},
             {"token", _token!.Token},
         };
@@ -161,7 +162,7 @@ public class LastFmService
         {
             if (e.Code != 14)
                 throw; // Only handle unauthorized token here
-            
+
             var process = new Process();
             process.StartInfo.UseShellExecute = true;
             process.StartInfo.FileName = $"https://www.last.fm/api/auth/?api_key={_appSettings.ApiKey}&token={_token.Token}";
@@ -174,13 +175,13 @@ public class LastFmService
             {
                 if (_logger.IsEnabled(LogLevel.Information))
                     _logger.LogInformation("Retrying auth.getSession");
-                
+
                 var result = await SendGetRequestAsync<LastFmGetSessionKeyResponseDc>(queryVals);
                 if (result?.Session?.Key is not null)
                 {
                     _session = result.Session;
                     regKey.SetValue(RegistrySessionKeyValueName, result.Session.Key);
-                    
+
                     return true;
                 }
 
@@ -196,12 +197,12 @@ public class LastFmService
 
         }, retryTimes: 15, baseBackOff: 5000, 30000);
     }
-    
+
     private async Task EnsureHasTokenAsync()
     {
         if (_token is not null && _token.ValidTo > DateTime.UtcNow)
             return;
-        
+
         var queryVals = new Dictionary<string, string>
         {
             {"method", "auth.gettoken"},
@@ -220,9 +221,9 @@ public class LastFmService
     private Dictionary<string, string> AddSignature(Dictionary<string, string> queryVals)
     {
         var copy = new Dictionary<string, string>(queryVals);
-        
+
         var signatureString = $"{string.Join(null, queryVals.OrderBy(kv => kv.Key).Select(kv => kv.Key + kv.Value))}{_appSettings.SharedSecret}";
-        
+
         copy.Add("api_sig", signatureString.AsMd5HexString());
         return copy;
     }
@@ -231,17 +232,15 @@ public class LastFmService
     {
         if (signRequest)
             queryVals = AddSignature(queryVals);
-        
+
         using var request = new HttpRequestMessage(HttpMethod.Get, BaseUrl.AddQueryString(queryVals));
         var result = await _client.SendAsync(request);
-        
-        if (!result.IsSuccessStatusCode)
+
+        // TODO: Handle error more gracefully
+        if (!result.IsSuccessStatusCode && await result.Content.ReadFromXmlAsync<LastFmErrorDc>() is LastFmErrorDc error)
         {
-            // TODO: Handle error more gracefully
-            var error = await result.Content.ReadFromXmlAsync<LastFmErrorDc>();
-            
             if (_logger.IsEnabled(LogLevel.Error))
-                _logger.LogError($"Got an error response from LastFM! code: {error?.Error.Code} - {error?.Error.Message}");
+                _logger.LogError($"Got an error response from LastFM! code: {error.Error.Code} - {error.Error.Message}");
             throw new LastFmErrorException(error.Error.Code, error.Error.Message);
         }
 
@@ -261,25 +260,23 @@ public class LastFmService
         request.Content = new FormUrlEncodedContent(signedFormData);
 
         var result = await _client.SendAsync(request);
-        if (!result.IsSuccessStatusCode)
+        if (!result.IsSuccessStatusCode && await result.Content.ReadFromXmlAsync<LastFmErrorDc>() is LastFmErrorDc error)
         {
-            var error = await result.Content.ReadFromXmlAsync<LastFmErrorDc>();
-            
             if (_logger.IsEnabled(LogLevel.Error))
-                _logger.LogError($"Got an error response from LastFM: {error?.Error.Code} - {error?.Error.Message}");
+                _logger.LogError($"Got an error response from LastFM: {error.Error.Code} - {error.Error.Message}");
             throw new LastFmErrorException(error.Error.Code, error.Error.Message);
         }
-        
-        #if DEBUG
+
+#if DEBUG
         var response = await result.Content.ReadAsStringAsync();
-        #endif
+#endif
     }
-    
+
     [XmlRoot("lfm")]
     public class AuthenticationToken
     {
         [XmlElement("token")]
-        public string Token { get; set; }
+        public string Token { get; set; } = string.Empty;
         public DateTime GrantedAt { get; } = DateTime.UtcNow;
 
         public DateTime ValidTo => GrantedAt.AddHours(1).AddMinutes(-5); // LastFM keys are valid for 1 hour.. So we request a new one every 55 minutes

--- a/Scrobbler/Models/LastFm/LastFmArtistDc.cs
+++ b/Scrobbler/Models/LastFm/LastFmArtistDc.cs
@@ -5,8 +5,8 @@ namespace Scrobbler.Models.LastFm;
 public class LastFmArtistDc
 {
     [XmlElement("mbid")]
-    public string MusicBrainzId { get; set; }
-    
+    public string MusicBrainzId { get; set; } = string.Empty;
+
     [XmlElement("name")]
-    public string Name { get; set; }
+    public string Name { get; set; } = string.Empty;
 }

--- a/Scrobbler/Models/LastFm/LastFmErrorDc.cs
+++ b/Scrobbler/Models/LastFm/LastFmErrorDc.cs
@@ -6,7 +6,7 @@ namespace Scrobbler.Models.LastFm;
 public class LastFmErrorDc
 {
     [XmlElement("error")]
-    public LastFmError Error { get; set; }
+    public LastFmError Error { get; set; } = new();
 }
 
 public class LastFmError
@@ -16,7 +16,7 @@ public class LastFmError
     /// </summary>
     [XmlText]
     public string Message { get; set; } = string.Empty;
-    
+
     /// <summary>
     /// LastFM Error Code. Consult the lastfm documentation for the failing endpoint
     /// </summary>

--- a/Scrobbler/Models/LastFm/LastFmErrorException.cs
+++ b/Scrobbler/Models/LastFm/LastFmErrorException.cs
@@ -1,3 +1,6 @@
 ﻿namespace Scrobbler.Models.LastFm;
 
-public class LastFmErrorException(int code, string message) : ApplicationException($"LastFm error: {code} - {message}");
+public class LastFmErrorException(int code, string message) : ApplicationException($"LastFm error: {code} - {message}")
+{
+    public int Code { get; } = code;
+}

--- a/Scrobbler/Models/LastFm/LastFmErrorException.cs
+++ b/Scrobbler/Models/LastFm/LastFmErrorException.cs
@@ -1,13 +1,3 @@
 ﻿namespace Scrobbler.Models.LastFm;
 
-public class LastFmErrorException : ApplicationException
-{
-    public LastFmErrorException(int code, string message) : base($"LastFm error: {code} - {message}")
-    {
-        Code = code;
-        Message = message;
-    }
-    
-    public int Code { get; }
-    public string Message { get; }
-}
+public class LastFmErrorException(int code, string message) : ApplicationException($"LastFm error: {code} - {message}");

--- a/Scrobbler/Models/LastFm/LastFmRequestBodyBase.cs
+++ b/Scrobbler/Models/LastFm/LastFmRequestBodyBase.cs
@@ -12,25 +12,25 @@ public abstract class LastFmRequestBodyBase
     /// A LastFM API key
     /// </summary>
     [JsonPropertyName("api_key")]
-    public string ApiKey { get; set; }
-    
+    public string ApiKey { get; set; } = string.Empty;
+
     /// <summary>
     /// A LastFM session key
     /// </summary>
     [JsonPropertyName("sk")]
-    public string SessionKey { get; set; }
-    
+    public string SessionKey { get; set; } = string.Empty;
+
     /// <summary>
     /// A LastFM method signature
     /// </summary>
     [JsonPropertyName("api_sig")]
-    public string ApiSignature { get; protected set; }
+    public string ApiSignature { get; protected set; } = string.Empty;
 
     /// <summary>
     /// The LastFM method to run
     /// </summary>
     [JsonPropertyName("method")]
     public abstract string Method { get; }
-    
+
     public abstract Dictionary<string, string> ToFormData();
 }

--- a/Scrobbler/Models/LastFm/LastFmScrobbleDc.cs
+++ b/Scrobbler/Models/LastFm/LastFmScrobbleDc.cs
@@ -5,33 +5,33 @@ public class LastFmScrobbleDc
     /// <summary>
     /// The name of the currently playing track
     /// </summary>
-    public string Track { get; set; }
-    
+    public string Track { get; set; } = string.Empty;
+
     /// <summary>
     /// the name of the track's artist
     /// </summary>
-    public string Artist { get; set; }
-    
+    public string Artist { get; set; } = string.Empty;
+
     /// <summary>
     /// The name of the track's album
     /// </summary>
-    public string Album { get; set; }
-    
+    public string Album { get; set; } = string.Empty;
+
     /// <summary>
     /// The name of the track's album's artist
     /// </summary>
-    public string AlbumArtist { get; set; }
-    
+    public string AlbumArtist { get; set; } = string.Empty;
+
     /// <summary>
     /// The track's number (on the album)
     /// </summary>
     public int TrackNumber { get; set; }
-    
+
     /// <summary>
     /// The duration of the track, in seconds
     /// </summary>
     public int Duration { get; set; }
-    
+
     /// <summary>
     /// The time the track started playing, in UNIX timestamp format.
     /// </summary>

--- a/Scrobbler/Models/LastFm/LastFmTrackDc.cs
+++ b/Scrobbler/Models/LastFm/LastFmTrackDc.cs
@@ -6,19 +6,19 @@ public class LastFmTrackDc
 {
     [XmlElement("id")]
     public int Id { get; set; }
-    
+
     [XmlElement("name")]
-    public string Name { get; set; }
-    
+    public string Name { get; set; } = string.Empty;
+
     /// <summary>
     /// Track duration, in milliseconds
     /// </summary>
     [XmlElement("duration")]
     public int? Duration { get; set; }
-    
+
     [XmlElement("album")]
     public LastFmAlbumDc? Album { get; set; }
-    
+
     [XmlElement("artist")]
     public LastFmArtistDc? Artist { get; set; }
 }

--- a/Scrobbler/Models/LastFm/LastFmUpdateNowPlayingRequestBody.cs
+++ b/Scrobbler/Models/LastFm/LastFmUpdateNowPlayingRequestBody.cs
@@ -6,32 +6,32 @@ namespace Scrobbler.Models.LastFm;
 public class LastFmUpdateNowPlayingRequestBody : LastFmRequestBodyBase
 {
     public override string Method => "track.updateNowPlaying";
-    
+
     /// <summary>
     /// The name of the currently playing track
     /// </summary>
     public string? Track { get; set; }
-    
+
     /// <summary>
     /// the name of the track's artist
     /// </summary>
     public string? Artist { get; set; }
-    
+
     /// <summary>
     /// The name of the track's album
     /// </summary>
     public string? Album { get; set; }
-    
+
     /// <summary>
     /// The name of the track's album's artist
     /// </summary>
     public string? AlbumArtist { get; set; }
-    
+
     /// <summary>
     /// The track's number (on the album)
     /// </summary>
     public int? TrackNumber { get; set; }
-    
+
     /// <summary>
     /// The duration of the track, in seconds
     /// </summary>
@@ -41,24 +41,24 @@ public class LastFmUpdateNowPlayingRequestBody : LastFmRequestBodyBase
     public override Dictionary<string, string> ToFormData()
     {
         var form = new Dictionary<string, string>();
-        
+
         if (Album.IsNonEmpty())
-            form.Add("album", Album);
+            form.Add("album", Album!);
 
         if (AlbumArtist.IsNonEmpty())
-            form.Add("albumArtist" ,AlbumArtist);
+            form.Add("albumArtist", AlbumArtist!);
 
         form.Add("api_key", ApiKey);
-        
-        form.Add("artist", Artist);
+
+        form.Add("artist", Artist ?? string.Empty);
 
         form.Add("duration", Duration.ToString());
 
         form.Add("method", Method);
-        
+
         form.Add("sk", SessionKey);
-        
-        form.Add("track", Track);
+
+        form.Add("track", Track ?? string.Empty);
 
         if (TrackNumber > 0)
             form.Add("trackNumber", TrackNumber.Value.ToString());

--- a/Scrobbler/Models/PlayingTrack.cs
+++ b/Scrobbler/Models/PlayingTrack.cs
@@ -16,7 +16,7 @@ public record TrackMetadata()
     /// <summary>
     /// The name of the track
     /// </summary>
-    public required string TrackName { get; init; }
+    public string TrackName { get; } = string.Empty;
 
     /// <summary>
     /// The duration of the track
@@ -26,7 +26,7 @@ public record TrackMetadata()
     /// <summary>
     /// The name of the track's artist
     /// </summary>
-    public required string ArtistName { get; init; }
+    public string ArtistName { get; } = string.Empty;
 
     /// <summary>
     /// The name of the track's album

--- a/Scrobbler/Models/PlayingTrack.cs
+++ b/Scrobbler/Models/PlayingTrack.cs
@@ -16,38 +16,38 @@ public record TrackMetadata()
     /// <summary>
     /// The name of the track
     /// </summary>
-    public string TrackName { get; }
-    
+    public required string TrackName { get; init; }
+
     /// <summary>
     /// The duration of the track
     /// </summary>
     public TimeSpan TrackDuration { get; set; }
-    
+
     /// <summary>
     /// The name of the track's artist
     /// </summary>
-    public string ArtistName { get; }
-    
+    public required string ArtistName { get; init; }
+
     /// <summary>
     /// The name of the track's album
     /// </summary>
     public string? AlbumName { get; }
-    
+
     /// <summary>
     /// The name of the track's album's artist. Can be null if the same as the track artist name
     /// </summary>
     public string? AlbumArtistName { get; }
-    
+
     /// <summary>
     /// the track number of the track
     /// </summary>
     public int? TrackNumber { get; }
-    
+
     /// <summary>
     /// The time the track started playing, in UTC
     /// </summary>
     public DateTime PlayingSince { get; }
-    
+
     public bool IsQueuedForScrobble { get; set; }
 
     public bool IsSameTrackAs(TrackMetadata? other) => other is not null

--- a/Scrobbler/Program.cs
+++ b/Scrobbler/Program.cs
@@ -4,7 +4,7 @@ using Scrobbler.Workers;
 
 var builder = Host.CreateApplicationBuilder(args);
 
-builder.Services.AddSingleton<AppSettings>(services => SettingsFactory.GetSettings(services.GetService<IConfiguration>()));
+builder.Services.AddSingleton(services => SettingsFactory.GetSettings(services.GetService<IConfiguration>()!));
 builder.Services.AddSingleton<HttpClient>();
 builder.Services.AddSingleton<LastFmService>();
 builder.Services.AddHostedService<ScrobblingService>();

--- a/Scrobbler/Scrobbler.csproj
+++ b/Scrobbler/Scrobbler.csproj
@@ -1,14 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
 
     <PropertyGroup>
-        <TargetFramework>net8.0-windows10.0.22000</TargetFramework>
+        <TargetFramework>netstandard2.1</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <UserSecretsId>dotnet-Scrobbler-aab8fea0-3f27-430b-8518-30920516cc95</UserSecretsId>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0"/>
-        <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Hosting"
+            Version="9.*" />
+        <PackageReference Include="System.Configuration.ConfigurationManager"
+            Version="9.*" />
     </ItemGroup>
 </Project>

--- a/Scrobbler/Scrobbler.csproj
+++ b/Scrobbler/Scrobbler.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>net8.0-windows;net9.0-windows</TargetFrameworks>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <UserSecretsId>dotnet-Scrobbler-aab8fea0-3f27-430b-8518-30920516cc95</UserSecretsId>

--- a/Scrobbler/Scrobbler.csproj
+++ b/Scrobbler/Scrobbler.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.1</TargetFramework>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <UserSecretsId>dotnet-Scrobbler-aab8fea0-3f27-430b-8518-30920516cc95</UserSecretsId>

--- a/Scrobbler/Scrobbler.csproj
+++ b/Scrobbler/Scrobbler.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Worker">
 
     <PropertyGroup>
-        <TargetFrameworks>net8.0-windows;net9.0-windows</TargetFrameworks>
+        <TargetFrameworks>net8.0-windows10.0.22000;net9.0-windows10.0.22000</TargetFrameworks>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <UserSecretsId>dotnet-Scrobbler-aab8fea0-3f27-430b-8518-30920516cc95</UserSecretsId>

--- a/Scrobbler/Util/AppSettings.cs
+++ b/Scrobbler/Util/AppSettings.cs
@@ -6,17 +6,17 @@ public class AppSettings
     /// If true, log output to X
     /// </summary>
     public bool UseLogging { get; set; }
-    
+
     /// <summary>
     /// The LastFM API Key
     /// </summary>
-    public string ApiKey { get; set; }
-    
+    public string ApiKey { get; set; } = string.Empty;
+
     /// <summary>
     /// LastFM Shared Secret
     /// </summary>
-    public string SharedSecret { get; set; }
-    
+    public string SharedSecret { get; set; } = string.Empty;
+
     /// <summary>
     /// The amount of time, in milliseconds, to wait after polling
     /// </summary>

--- a/Scrobbler/Workers/ScrobblingService.cs
+++ b/Scrobbler/Workers/ScrobblingService.cs
@@ -1,9 +1,9 @@
 using System.Collections.Concurrent;
-using Windows.Media;
-using Windows.Media.Control;
 using Scrobbler.Core;
 using Scrobbler.Models;
 using Scrobbler.Util;
+using Windows.Media;
+using Windows.Media.Control;
 
 namespace Scrobbler.Workers;
 
@@ -13,13 +13,13 @@ public class ScrobblingService(ILogger<ScrobblingService> logger, AppSettings ap
     private GlobalSystemMediaTransportControlsSession? _session;
 
     private TrackMetadata? _currentlyPlaying;
-    
+
     private const int MinTrackLengthInSeconds = 30;
     private const int ScrobblingBatchSize = 50;
-    
+
     private DateTime _lastScrobbledTime = DateTime.UtcNow;
     private ConcurrentQueue<TrackMetadata> _scrobbleQueue = new();
-    
+
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         await lastFmService.EnsureAuthenticatedAsync();
@@ -29,33 +29,33 @@ public class ScrobblingService(ILogger<ScrobblingService> logger, AppSettings ap
         while (!stoppingToken.IsCancellationRequested)
         {
             var playbackInfo = _session?.GetPlaybackInfo();
-            if (playbackInfo is {PlaybackStatus: GlobalSystemMediaTransportControlsSessionPlaybackStatus.Playing})// && _currentlyPlaying is not null)
+            if (playbackInfo is { PlaybackStatus: GlobalSystemMediaTransportControlsSessionPlaybackStatus.Playing })// && _currentlyPlaying is not null)
             {
-                if (TrackCanBeScrobbled(_currentlyPlaying))
+                if (_currentlyPlaying is not null && TrackCanBeScrobbled(_currentlyPlaying))
                     EnqueueForScrobbling(_currentlyPlaying);
             }
-            
-            // if (logger.IsEnabled(LogLevel.Debug)) 
+
+            // if (logger.IsEnabled(LogLevel.Debug))
             //     logger.LogDebug($"Playback status: {playbackInfo.PlaybackStatus}. Playing {_currentlyPlaying?.ArtistName} - {_currentlyPlaying?.TrackName} (Playtime: {DateTime.UtcNow - _currentlyPlaying?.PlayingSince})");
 
             // If we haven't scrobbled for 15 minutes, do so
             if (_lastScrobbledTime < DateTime.UtcNow.AddMinutes(-15))
                 await ProcessScrobbleQueueAsync();
-            
+
             await Task.Delay(appSettings.PollTime, stoppingToken);
         }
     }
 
     /// <summary>
     /// <para>Checks whether a given track can be scrobbled.</para>
-    /// 
+    ///
     /// LastFM has some rules regarding when a track can be scrobbled:
-    /// 
+    ///
     /// <list type="bullet">
     ///     <item>Must be at least 30 seconds long</item>
     ///     <item>Must have been playing for at least half its duration, or for 4 minutes, whichever comes first</item>
     /// </list>
-    /// 
+    ///
     /// </summary>
     /// <remarks>See the LastFM docs for more information: https://www.last.fm/api/scrobbling#when-is-a-scrobble-a-scrobble</remarks>
     /// <remarks>The currently playing track</remarks>
@@ -65,19 +65,19 @@ public class ScrobblingService(ILogger<ScrobblingService> logger, AppSettings ap
                && track.TrackDuration.TotalSeconds > MinTrackLengthInSeconds
                && track.PlayingSince < DateTime.UtcNow - (track.TrackDuration / 2);
     }
-    
+
     private async Task InitializeAsync(CancellationToken stoppingToken)
     {
         // Get manager and current session
         _manager = await GlobalSystemMediaTransportControlsSessionManager.RequestAsync();
         _session = _manager.GetCurrentSession();
-        
+
         // Listen to changes to Current Session
         _manager.CurrentSessionChanged += OnCurrentSessionChanged;
         InitializeSession(_session);
 
         await UpdateCurrentTrackAsync(_session);
-        
+
         // Register shutdown method
         stoppingToken.Register(ShutDown);
     }
@@ -85,7 +85,7 @@ public class ScrobblingService(ILogger<ScrobblingService> logger, AppSettings ap
     private async Task UpdateCurrentTrackAsync(GlobalSystemMediaTransportControlsSession session)
     {
         TrackMetadata? newTrack = null;
-        
+
         var mediaProperties = await session.TryGetMediaPropertiesAsync();
         if (mediaProperties.PlaybackType == MediaPlaybackType.Music)
         {
@@ -105,7 +105,7 @@ public class ScrobblingService(ILogger<ScrobblingService> logger, AppSettings ap
                 _currentlyPlaying = track;
                 return;
             }
-            
+
             // There is some weirdness here, which is caused by the browser pretty much always being classified as music.
             // To work around this, I try to query LastFM to see if the track exists.
             var lastFmTrackMetadata = await lastFmService.GetTrackAsync(track.TrackName, track.ArtistName);
@@ -113,7 +113,7 @@ public class ScrobblingService(ILogger<ScrobblingService> logger, AppSettings ap
                                                                   || lastFmTrackMetadata.Album?.Title != null
                                                                   || lastFmTrackMetadata.Duration > 30
                                                                   || lastFmTrackMetadata.Artist?.MusicBrainzId != null);
-            
+
             if (trackExists)
             {
                 // For some reason, Windows sometimes reports crazy long track durations, so tracks don't get scrobbled.
@@ -121,16 +121,16 @@ public class ScrobblingService(ILogger<ScrobblingService> logger, AppSettings ap
                 if (lastFmTrackMetadata!.Duration > (MinTrackLengthInSeconds * 1000) && lastFmTrackMetadata?.Duration < track.TrackDuration.TotalMilliseconds)
                 {
                     var lastFmTrackDuration = TimeSpan.FromMilliseconds(lastFmTrackMetadata.Duration.Value);
-                    
-                    if (logger.IsEnabled(LogLevel.Debug)) 
+
+                    if (logger.IsEnabled(LogLevel.Debug))
                         logger.LogDebug($"Replacing Windows track duration {track.TrackDuration} with LastFM duration {lastFmTrackDuration}");
                     track.TrackDuration = lastFmTrackDuration;
                 }
-                
+
                 newTrack = track;
-                if (logger.IsEnabled(LogLevel.Debug)) 
+                if (logger.IsEnabled(LogLevel.Debug))
                     logger.LogDebug($"Now playing: {track?.ArtistName} - {track?.TrackName}, duration {track?.TrackDuration}");
-                
+
                 if (track is not null)
                     await lastFmService.UpdateCurrentlyPlayingAsync(track);
             }
@@ -141,11 +141,11 @@ public class ScrobblingService(ILogger<ScrobblingService> logger, AppSettings ap
             }
         }
 
-        if (_currentlyPlaying is not null && TrackCanBeScrobbled(_currentlyPlaying))
-            EnqueueForScrobbling(_currentlyPlaying);
+        if (TrackCanBeScrobbled(_currentlyPlaying))
+            EnqueueForScrobbling(_currentlyPlaying!);
         _currentlyPlaying = newTrack;
     }
-    
+
     private void InitializeSession(GlobalSystemMediaTransportControlsSession session)
     {
         session.MediaPropertiesChanged += OnMediaPropertiesChangedAsync;
@@ -155,18 +155,18 @@ public class ScrobblingService(ILogger<ScrobblingService> logger, AppSettings ap
     {
         session.MediaPropertiesChanged -= OnMediaPropertiesChangedAsync;
     }
-    
+
     private void ShutDown()
     {
         if (logger.IsEnabled(LogLevel.Information))
             logger.LogInformation("Cleaning up resources..");
-        
+
         if (_manager is null)
             return;
 
         if (_session is not null)
             CloseSession(_session);
-        
+
         _manager.CurrentSessionChanged -= OnCurrentSessionChanged;
     }
 
@@ -179,9 +179,9 @@ public class ScrobblingService(ILogger<ScrobblingService> logger, AppSettings ap
 
             track.IsQueuedForScrobble = true;
         }
-        
+
         _scrobbleQueue.Enqueue(track);
-        
+
         if (logger.IsEnabled(LogLevel.Information))
             logger.LogInformation($"Added track to scrobbling queue: {track.ArtistName} - {track.TrackName}");
     }
@@ -191,27 +191,27 @@ public class ScrobblingService(ILogger<ScrobblingService> logger, AppSettings ap
         _lastScrobbledTime = DateTime.UtcNow;
 
         if (logger.IsEnabled(LogLevel.Trace))
-            logger.LogTrace($"Processing scrobble queue with {_scrobbleQueue.Count} tracks");   
-        
+            logger.LogTrace($"Processing scrobble queue with {_scrobbleQueue.Count} tracks");
+
         var scrobbleBatch = new List<TrackMetadata>();
         for (var i = 0; i < ScrobblingBatchSize; i++)
         {
             if (!_scrobbleQueue.TryDequeue(out var track))
                 break;
-            
+
             scrobbleBatch.Add(track);
         }
 
         if (scrobbleBatch.Count == 0)
             return;
-        
+
         var success = await lastFmService.ScrobbleTracksAsync(scrobbleBatch);
         if (!success)
         {
             scrobbleBatch.ForEach(_scrobbleQueue.Enqueue);
         }
     }
-    
+
     private void OnCurrentSessionChanged(GlobalSystemMediaTransportControlsSessionManager sender, CurrentSessionChangedEventArgs args)
     {
         if (_session is not null)
@@ -220,15 +220,15 @@ public class ScrobblingService(ILogger<ScrobblingService> logger, AppSettings ap
         var session = sender.GetCurrentSession();
         if (session is null)
             return;
-        
+
         if (logger.IsEnabled(LogLevel.Trace))
             logger.LogTrace($"New session: {session.SourceAppUserModelId}");
-        
+
         InitializeSession(session);
         _session = session;
-        
+
     }
-    
+
     private async void OnMediaPropertiesChangedAsync(GlobalSystemMediaTransportControlsSession sender, MediaPropertiesChangedEventArgs args)
     {
         await UpdateCurrentTrackAsync(sender);

--- a/Scrobbler/Workers/ScrobblingService.cs
+++ b/Scrobbler/Workers/ScrobblingService.cs
@@ -59,7 +59,7 @@ public class ScrobblingService(ILogger<ScrobblingService> logger, AppSettings ap
     /// </summary>
     /// <remarks>See the LastFM docs for more information: https://www.last.fm/api/scrobbling#when-is-a-scrobble-a-scrobble</remarks>
     /// <remarks>The currently playing track</remarks>
-    private bool TrackCanBeScrobbled(TrackMetadata? track)
+    private static bool TrackCanBeScrobbled(TrackMetadata? track)
     {
         return track is not null
                && track.TrackDuration.TotalSeconds > MinTrackLengthInSeconds


### PR DESCRIPTION
Most of these changes are silencing [`CS8618` warnings](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/nullable-warnings#nonnullable-reference-not-initialized) in places where dotnet will technically insert a null value in the default-generated empty constructor.
The rest is small cleanup stuff, removal of whitespace on empty lines, etc. as well as bumping both dependencies (they still explicitly support dotnet 8 so nothing changes there).

I'd recommended squash merging this as most of these commits are smaller steps in fixing the rather large list of build warnings.

I tried looking into a broader target framework, but then the SDK doesn't load in the Desktop components for `System.Windows.Media` in a `Worker` SDK project. So instead I ended up just adding a dotnet 9 target for some optimizations where possible.
I also tried running the suggested `required` on some props, but those don't actually work on constructors inheriting their base constructor.